### PR TITLE
garnet: Address missing SetTaskProfiles symbol in camera libs

### DIFF
--- a/extract-files.py
+++ b/extract-files.py
@@ -104,6 +104,11 @@ blob_fixups: blob_fixups_user_type = {
     'vendor/etc/seccomp_policy/wfdhdcphalservice.policy',
     ): blob_fixup()
         .add_line_if_missing('gettid: 1'),
+    (
+    'vendor/lib64/hw/com.qti.chi.override.so',
+    'vendor/lib64/libcamxcommonutils.so',
+    'vendor/lib64/libmialgoengine.so',
+    ): blob_fixup().add_needed('libprocessgroup_shim.so'),
     'vendor/etc/seccomp_policy/c2audio.vendor.ext-arm64.policy': blob_fixup()
         .add_line_if_missing('setsockopt: 1'),
     'vendor/etc/media_codecs_parrot_v0.xml': blob_fixup()


### PR DESCRIPTION
The camera HAL forced stop because it could not load /vendor/lib64/hw/camera.xiaomi.so which is due to the missing `SetTaskProfiles` symbol referenced in several libraries:

fiqri@Fiqri:~/proprietary_vendor_xiaomi_marble$ grep -i -r SetTaskProfiles grep: proprietary/vendor/lib64/hw/com.qti.chi.override.so: binary file matches grep: proprietary/vendor/lib64/libmialgoengine.so: binary file matches grep: proprietary/vendor/lib64/libcamxcommonutils.so: binary file matches

This is because DECLS was removed in [1] on Android 15 QPR2, and caused SetTaskProfiles() to be hidden, so shim SetTaskProfiles with libprocessgroup_shim.

[1]: https://cs.android.com/android/_/android/platform/system/core/+/3e7c17a8e7ad7275ea3a65642608b1c0becb38ad

Change-Id: Ic46aae47bdf6be09736fe89d798cb7017f07cc6c